### PR TITLE
Add hidden tag to all sub-pieces

### DIFF
--- a/mobs/bird.yml
+++ b/mobs/bird.yml
@@ -77,6 +77,7 @@ bird:
 
 bird0:
   name: "Bird"
+  hidden: true
   persist: true
   potion_effects:
     invisibility: 0

--- a/mobs/deer.yml
+++ b/mobs/deer.yml
@@ -1,4 +1,5 @@
 deer0:
+  hidden: true
   type: horse
   horse_color: creamy
   baby: true
@@ -38,6 +39,7 @@ deer:
     protected: true
 
 moose0:
+  hidden: true
   type: horse
   horse_color: brown
   silent: true

--- a/mobs/frog.yml
+++ b/mobs/frog.yml
@@ -17,6 +17,7 @@ frog:
   - frog0
 
 frog0:
+  hidden: true
   type: slime
   size: 2
   split: false

--- a/mobs/penguin.yml
+++ b/mobs/penguin.yml
@@ -17,7 +17,9 @@ penguin:
   remove_mounts:
   - penguin0
   - penguin00
+
 penguin0:
+  hidden: true
   type: zombie
   baby: true
   silent: true
@@ -46,7 +48,9 @@ penguin0:
   remove_mounts:
   - penguin
   - penguin00
+
 penguin00:
+  hidden: true
   type: chicken
   baby: true
   silent: true

--- a/mobs/shroom.yml
+++ b/mobs/shroom.yml
@@ -1,4 +1,5 @@
 shroom0:
+  hidden: true
   type: rabbit
   silent: true
   baby: true


### PR DESCRIPTION
In the next build this tag will keep the sub-parts from showing up in `/mmob spawn` tab-completion and various other places.

They'll still show up in `/mconfig editor mob` tab-completion.