### PR TITLE
Don't name all zombies

### DIFF
--- a/mobs/zombies/zombies.yml
+++ b/mobs/zombies/zombies.yml
@@ -20,10 +20,6 @@ rotten_zombie:
     death:
       cast: rotten_zombie
 
-zombie:
-  type: zombie
-  name: "Zombie"
-
 zombie_miner:
   type: zombie
   name: "Zombie Miner"


### PR DESCRIPTION
Putting `zombie` in here also affects all naturally-spawned zombies, which means they all get names.

These:
```
Named entity EntityZombie['Zombie'/911, uuid='3d5c6301-90f4-41d4-80c4-3c6e4e9ad049', l='ServerLevel[world]', x=-17112.53, y=70.00, z=-7164.75, cpos=[-1070, -448], tl=276, v=true, rR=null] died: Zombie burned to death
```

Have been driving me nuts 😂 and I finally figured out where it was coming from.